### PR TITLE
Expand TextMacros in descriptions' 2ndary titles.

### DIFF
--- a/src/PurplePen/DescriptionFormatter.cs
+++ b/src/PurplePen/DescriptionFormatter.cs
@@ -175,22 +175,16 @@ namespace PurplePen
         // Given the text, create descriptions line for a title line with that text. Lines are split by vertical bars.
         private DescriptionLine[] GetTitleLineFromText(DescriptionLineKind kind, string text)
         {
-            string[] texts = text.Split(new char[] { '|' });
-            int lineCount = texts.Length;
-
-            DescriptionLine[] lines = new DescriptionLine[lineCount];
-            for (int index = 0; index < lineCount; ++index) {
-                DescriptionLine line = new DescriptionLine();
-
-                line.kind = kind;
-                line.boxes = new object[1];
-                line.boxes[0] = texts[index];
-                line.textual = texts[index];
-
-                lines[index] = line;
-            }
-
-            return lines;
+            return text.Split(new char[] { '|' })
+                .ConvertAll(t =>
+                {
+                    DescriptionLine line = new DescriptionLine();
+                    line.kind = kind;
+                    line.boxes = new object[1];
+                    line.boxes[0] = t;
+                    line.textual = CourseFormatter.ExpandText(eventDB, courseView, t);
+                    return line;
+                });
         }
 
         // Create a description line for a normal header line: name, length, climb
@@ -274,23 +268,19 @@ namespace PurplePen
         // Given the text, create one or more text lines for that text. Lines are split by vertical bars.
         private DescriptionLine[] GetTextLineFromText(string text, Id<CourseControl> courseControlId, Id<ControlPoint> controlId, DescriptionLine.TextLineKind textLineKind)
         {
-            string[] texts = text.Split(new char[] { '|' });
-            int lineCount = texts.Length;
-
-            DescriptionLine[] lines = new DescriptionLine[lineCount];
-            for (int index = 0; index < lineCount; ++index) {
-                DescriptionLine line = new DescriptionLine();
-                line.kind = DescriptionLineKind.Text;
-                line.boxes = new object[1];
-                line.boxes[0] = texts[index];
-                line.textual = texts[index];
-                line.courseControlId = courseControlId;
-                line.controlId = controlId;
-                line.textLineKind = textLineKind;
-                lines[index] = line;
-            }
-
-            return lines;
+            return text.Split(new char[] { '|' })
+                .ConvertAll(t =>
+                {
+                    DescriptionLine line = new DescriptionLine();
+                    line.kind = DescriptionLineKind.Text;
+                    line.boxes = new object[1];
+                    line.boxes[0] = t;
+                    line.textual = CourseFormatter.ExpandText(eventDB, courseView, t);
+                    line.courseControlId = courseControlId;
+                    line.controlId = controlId;
+                    line.textLineKind = textLineKind;
+                    return line;
+                });
         }
 
         // Given some text, a text line for it to a list if the text is non-empty.

--- a/src/PurplePen/DescriptionFormatter.cs
+++ b/src/PurplePen/DescriptionFormatter.cs
@@ -608,7 +608,7 @@ namespace PurplePen
             DescriptionLine line;
             DescriptionLine[] lines;
             Dictionary<string, string> descriptionKey = new Dictionary<string, string>(); // dictionary for any symbols encountered with custom text.
-
+            
             // Get the first title line.
             text = GetTitleLine1();
             Debug.Assert(text != null);
@@ -618,7 +618,7 @@ namespace PurplePen
             // Get the second title line.
             text = GetTitleLine2();
             if (text != null) {
-                lines = GetTitleLineFromText(DescriptionLineKind.SecondaryTitle, text);
+                lines = GetTitleLineFromText(DescriptionLineKind.SecondaryTitle, CourseFormatter.ExpandText(eventDB, courseView, text));
                 list.AddRange(lines);
             }
 

--- a/src/PurplePen/DescriptionRenderer.cs
+++ b/src/PurplePen/DescriptionRenderer.cs
@@ -719,11 +719,11 @@ namespace PurplePen
 
             switch (descriptionLine.kind) {
                 case DescriptionLineKind.Title:
-                    RenderSingleLineText(renderer, TITLE_FONT, StringAlignment.Center, (string) (descriptionLine.boxes[0]), 0, 0, fullWidth, 100, clipRect);
+                    RenderSingleLineText(renderer, TITLE_FONT, StringAlignment.Center, (string) (descriptionLine.textual), 0, 0, fullWidth, 100, clipRect);
                     break;
 
                 case DescriptionLineKind.SecondaryTitle:
-                    RenderSingleLineText(renderer, TITLE_FONT, StringAlignment.Center, (string) (descriptionLine.boxes[0]), 0, 0, fullWidth, 100, clipRect);
+                    RenderSingleLineText(renderer, TITLE_FONT, StringAlignment.Center, (string) (descriptionLine.textual), 0, 0, fullWidth, 100, clipRect);
                     break;
 
                 case DescriptionLineKind.Header2Box:
@@ -810,7 +810,7 @@ namespace PurplePen
                     break;
 
                 case DescriptionLineKind.Text:
-                    RenderWrappedText(renderer, TEXTLINE_FONT, StringAlignment.Near, (string) (descriptionLine.boxes[0]), 20, 0, fullWidth, 100, clipRect);
+                    RenderWrappedText(renderer, TEXTLINE_FONT, StringAlignment.Near, (string) (descriptionLine.textual), 20, 0, fullWidth, 100, clipRect);
                     break;
 
                 default:

--- a/src/PurplePen/PurplePen.csproj
+++ b/src/PurplePen/PurplePen.csproj
@@ -172,6 +172,7 @@
       <DependentUpon>ChangeText.cs</DependentUpon>
     </Compile>
     <Compile Include="CircleGap.cs" />
+    <Compile Include="SystemExtensions.cs" />
     <Compile Include="ColorChooserDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1500,6 +1501,7 @@
     <EmbeddedResource Include="CommandNameText.pl.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>CommandNameText.pl.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="CommandNameText.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/PurplePen/SystemExtensions.cs
+++ b/src/PurplePen/SystemExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace PurplePen
+{
+    public static class SystemExtensions
+    {
+        public static TResult[] ConvertAll<TSource, TResult>(this TSource[] _, Converter<TSource, TResult> converter)
+        {
+            return Array.ConvertAll(_, converter);
+        }
+    }
+}


### PR DESCRIPTION
Allows using $(PrintScale) in the secondary title so that we will never miss the scale information in our prints (again). Probably other benefits too. 