### PR TITLE
Use relative to 1:15000 item scaling on a new 1:7500 map

### DIFF
--- a/src/PurplePen/Controller.cs
+++ b/src/PurplePen/Controller.cs
@@ -544,7 +544,7 @@ namespace PurplePen
                 ev.courseAppearance.itemScaling = ItemScaling.RelativeToMap;
             }
             else {
-                if (info.allControlsPrintScale >= 9500 && info.allControlsPrintScale <= 15500) {
+                if (info.allControlsPrintScale >= 7500 && info.allControlsPrintScale <= 15500) {
                     ev.courseAppearance.itemScaling = ItemScaling.RelativeTo15000;
                 }
                 else {

--- a/src/PurplePen_Tests/PurplePen/ControllerTests.cs
+++ b/src/PurplePen_Tests/PurplePen/ControllerTests.cs
@@ -181,6 +181,7 @@ Invalid control point kind 'norfmal''
             Assert.AreEqual(MapType.OCAD, e.mapType);
             Assert.AreEqual(10000, e.mapScale);
             Assert.AreEqual(7500, e.allControlsPrintScale);
+            Assert.AreEqual(ItemScaling.RelativeTo15000, e.courseAppearance.itemScaling);
             Assert.AreEqual(DescriptionKind.Symbols, e.allControlsDescKind);
             Assert.AreEqual(100, e.firstControlCode);
             Assert.AreEqual(true, e.disallowInvertibleCodes);


### PR DESCRIPTION
When creating new maps with 1:7500 print scale with latest map standard, the obvious and correct item scaling is "Relative to 1:15000" which should be the default.