### PR TITLE
Custom color overprint

### DIFF
--- a/src/PurplePen/ColorChooserDialog.Designer.cs
+++ b/src/PurplePen/ColorChooserDialog.Designer.cs
@@ -38,6 +38,7 @@
             this.upDownCyan = new System.Windows.Forms.NumericUpDown();
             this.groupBoxPreview = new System.Windows.Forms.GroupBox();
             this.pictureBoxPreview = new System.Windows.Forms.PictureBox();
+            this.checkBoxOverprint = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.upDownBlack)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.upDownYellow)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.upDownMagenta)).BeginInit();
@@ -117,10 +118,17 @@
             this.pictureBoxPreview.TabStop = false;
             this.pictureBoxPreview.Paint += new System.Windows.Forms.PaintEventHandler(this.pictureBoxPreview_Paint);
             // 
+            // checkBoxOverprint
+            // 
+            resources.ApplyResources(this.checkBoxOverprint, "checkBoxOverprint");
+            this.checkBoxOverprint.Name = "checkBoxOverprint";
+            this.checkBoxOverprint.UseVisualStyleBackColor = true;
+            // 
             // ColorChooserDialog
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.Controls.Add(this.checkBoxOverprint);
             this.Controls.Add(this.groupBoxPreview);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.upDownBlack);
@@ -142,6 +150,7 @@
             this.Controls.SetChildIndex(this.upDownBlack, 0);
             this.Controls.SetChildIndex(this.label5, 0);
             this.Controls.SetChildIndex(this.groupBoxPreview, 0);
+            this.Controls.SetChildIndex(this.checkBoxOverprint, 0);
             ((System.ComponentModel.ISupportInitialize)(this.upDownBlack)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.upDownYellow)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.upDownMagenta)).EndInit();
@@ -165,5 +174,6 @@
         private System.Windows.Forms.NumericUpDown upDownCyan;
         private System.Windows.Forms.GroupBox groupBoxPreview;
         private System.Windows.Forms.PictureBox pictureBoxPreview;
+        private System.Windows.Forms.CheckBox checkBoxOverprint;
     }
 }

--- a/src/PurplePen/ColorChooserDialog.cs
+++ b/src/PurplePen/ColorChooserDialog.cs
@@ -35,6 +35,19 @@ namespace PurplePen
             }
         }
 
+        public bool Overprint
+        {
+            get
+            {
+                return checkBoxOverprint.Checked;
+            }
+            set
+            {
+                checkBoxOverprint.Checked = value;
+            }
+        }
+
+
         private void pictureBoxPreview_Paint(object sender, PaintEventArgs e)
         {
             e.Graphics.Clear(SwopColorConverter.CmykToRgbColor(Color));
@@ -88,7 +101,7 @@ namespace PurplePen
                 }
 
                 if (index == comboBox.Items.Count - 1)
-                    comboBox.Items[index] = new ColorAndText(MiscText.CustomColor, value.CustomColor);
+                    comboBox.Items[index] = new ColorAndText(MiscText.CustomColor, value.CustomColor, value.Overprint);
                 comboBox.SelectedIndex = index;
             }
         }
@@ -112,11 +125,11 @@ namespace PurplePen
             comboBox.Items.Add(new ColorAndText(MiscText.Black, SpecialColor.Black, CmykColor.FromCmyk(0, 0, 0, 1)));
             comboBox.Items.Add(new ColorAndText(MiscText.Purple, SpecialColor.UpperPurple, purpleColor));
             comboBox.Items.Add(new ColorAndText(MiscText.LowerPurple, SpecialColor.LowerPurple, purpleColor));
-            comboBox.Items.Add(new ColorAndText(MiscText.Red, CmykColor.FromCmyk(0, 1, 1, 0)));
-            comboBox.Items.Add(new ColorAndText(MiscText.Yellow, CmykColor.FromCmyk(0, 0, 1, 0)));
-            comboBox.Items.Add(new ColorAndText(MiscText.Green, CmykColor.FromCmyk(1, 0, 1, 0)));
-            comboBox.Items.Add(new ColorAndText(MiscText.LightBlue, CmykColor.FromCmyk(1, 0, 0, 0)));
-            comboBox.Items.Add(new ColorAndText(MiscText.DarkBlue, CmykColor.FromCmyk(1, 1, 0, 0)));
+            comboBox.Items.Add(new ColorAndText(MiscText.Red, CmykColor.FromCmyk(0, 1, 1, 0), false));
+            comboBox.Items.Add(new ColorAndText(MiscText.Yellow, CmykColor.FromCmyk(0, 0, 1, 0), false));
+            comboBox.Items.Add(new ColorAndText(MiscText.Green, CmykColor.FromCmyk(1, 0, 1, 0), false));
+            comboBox.Items.Add(new ColorAndText(MiscText.LightBlue, CmykColor.FromCmyk(1, 0, 0, 0), false));
+            comboBox.Items.Add(new ColorAndText(MiscText.DarkBlue, CmykColor.FromCmyk(1, 1, 0, 0), false));
             comboBox.Items.Add(new ColorAndText(MiscText.CustomColor, null, null));
         }
 
@@ -165,7 +178,7 @@ namespace PurplePen
         {
             if (((ColorAndText)comboBox.SelectedItem).SpecialColor == null) {
                 // The "Custom Color" item was selected, but no color is in it.
-                CustomizeColor(CmykColor.FromCmyk(0, 0, 0, 0));
+                CustomizeColor(CmykColor.FromCmyk(0, 0, 0, 0), false);
             }
 
 
@@ -174,16 +187,17 @@ namespace PurplePen
 
         void button_Click(object sender, EventArgs e)
         {
-            CustomizeColor(Color.CustomColor ?? CmykColor.FromCmyk(0, 0, 0, 0));
+            CustomizeColor(Color.CustomColor ?? CmykColor.FromCmyk(0, 0, 0, 0), Color.Overprint);
         }
 
-        private void CustomizeColor(CmykColor color)
+        private void CustomizeColor(CmykColor color, bool overprint)
         {
             ColorChooserDialog colorChooserDialog = new ColorChooserDialog();
             colorChooserDialog.Color = color;
+            colorChooserDialog.Overprint = overprint;
 
             if (colorChooserDialog.ShowDialog() == DialogResult.OK) {
-                Color = new SpecialColor(colorChooserDialog.Color);
+                Color = new SpecialColor(colorChooserDialog.Color, colorChooserDialog.Overprint);
             }
 
             colorChooserDialog.Dispose();
@@ -205,10 +219,10 @@ namespace PurplePen
                 this.Color = color;
             }
 
-            public ColorAndText(string text, CmykColor color)
+            public ColorAndText(string text, CmykColor color, bool overprint)
             {
                 this.Text = text;
-                this.SpecialColor = new SpecialColor(color);
+                this.SpecialColor = new SpecialColor(color, overprint);
                 this.Color = color;
             }
 

--- a/src/PurplePen/ColorChooserDialog.resx
+++ b/src/PurplePen/ColorChooserDialog.resx
@@ -135,7 +135,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;okButton.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
     <value>244, 184</value>
@@ -153,7 +153,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -184,7 +184,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="upDownBlack.Location" type="System.Drawing.Point, System.Drawing">
     <value>261, 49</value>
@@ -205,7 +205,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;upDownBlack.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -235,7 +235,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="upDownYellow.Location" type="System.Drawing.Point, System.Drawing">
     <value>90, 49</value>
@@ -256,7 +256,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;upDownYellow.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -286,7 +286,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="upDownMagenta.Location" type="System.Drawing.Point, System.Drawing">
     <value>261, 21</value>
@@ -307,7 +307,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;upDownMagenta.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -337,7 +337,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="upDownCyan.Location" type="System.Drawing.Point, System.Drawing">
     <value>90, 21</value>
@@ -358,7 +358,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;upDownCyan.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="groupBoxPreview.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
@@ -412,6 +412,33 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBoxPreview.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="checkBoxOverprint.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkBoxOverprint.Location" type="System.Drawing.Point, System.Drawing">
+    <value>21, 189</value>
+  </data>
+  <data name="checkBoxOverprint.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 17</value>
+  </data>
+  <data name="checkBoxOverprint.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="checkBoxOverprint.Text" xml:space="preserve">
+    <value>Overprint</value>
+  </data>
+  <data name="&gt;&gt;checkBoxOverprint.Name" xml:space="preserve">
+    <value>checkBoxOverprint</value>
+  </data>
+  <data name="&gt;&gt;checkBoxOverprint.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkBoxOverprint.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;checkBoxOverprint.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -436,6 +463,6 @@
     <value>ColorChooserDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>PurplePen.OkCancelDialog, PurplePen, Version=2.3.0.110, Culture=neutral, PublicKeyToken=null</value>
+    <value>PurplePen.OkCancelDialog, PurplePen, Version=3.5.3.500, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/src/PurplePen/CourseLayout.cs
+++ b/src/PurplePen/CourseLayout.cs
@@ -189,8 +189,9 @@ namespace PurplePen
                     if (courseObject.CustomColor != null && courseObject.CustomColor.Kind == SpecialColor.ColorKind.Custom) {
                         if (!customColors.ContainsKey(courseObject.CustomColor)) {
                             CmykColor cmyk = courseObject.CustomColor.CustomColor;
+                            bool overprint = courseObject.CustomColor.Overprint;
                             customColors.Add(courseObject.CustomColor, map.AddColor(string.Format("Color {0}", customColorId), customColorId,
-                                                                                    cmyk.Cyan, cmyk.Magenta, cmyk.Yellow, cmyk.Black, false));
+                                                                                    cmyk.Cyan, cmyk.Magenta, cmyk.Yellow, cmyk.Black, overprint));
                             ++customColorId;
                         }
                     }

--- a/src/PurplePen/EventDB.cs
+++ b/src/PurplePen/EventDB.cs
@@ -1576,27 +1576,31 @@ namespace PurplePen
 
         public readonly ColorKind Kind;
         public readonly CmykColor CustomColor;
+        public readonly bool Overprint;
 
-        public readonly static SpecialColor Black = new SpecialColor(ColorKind.Black);
-        public readonly static SpecialColor UpperPurple = new SpecialColor(ColorKind.UpperPurple);
-        public readonly static SpecialColor LowerPurple = new SpecialColor(ColorKind.LowerPurple);
+        public readonly static SpecialColor Black = new SpecialColor(ColorKind.Black, false);
+        public readonly static SpecialColor UpperPurple = new SpecialColor(ColorKind.UpperPurple, false);
+        public readonly static SpecialColor LowerPurple = new SpecialColor(ColorKind.LowerPurple, false);
 
-        public SpecialColor(ColorKind colorKind)
+        public SpecialColor(ColorKind colorKind, bool overprint)
         {
             Debug.Assert(colorKind != ColorKind.Custom);
             this.Kind = colorKind;
+            this.Overprint = overprint;
         }
 
-        public SpecialColor(float cyan, float magenta, float yellow, float black)
+        public SpecialColor(float cyan, float magenta, float yellow, float black, bool overprint)
         {
             this.Kind = ColorKind.Custom;
             this.CustomColor = CmykColor.FromCmyk(cyan, magenta, yellow, black);
+            this.Overprint = overprint;
         }
 
-        public SpecialColor(CmykColor color)
+        public SpecialColor(CmykColor color, bool overprint)
         {
             this.Kind = ColorKind.Custom;
             this.CustomColor = color;
+            this.Overprint = overprint;
         }
 
         public override string ToString()
@@ -1605,7 +1609,7 @@ namespace PurplePen
                 case ColorKind.Black: return "black";
                 case ColorKind.UpperPurple: return "purple";
                 case ColorKind.LowerPurple: return "lower-purple";
-                case ColorKind.Custom: return string.Format(CultureInfo.InvariantCulture, "{0:F},{1:F},{2:F},{3:F}", CustomColor.Cyan, CustomColor.Magenta, CustomColor.Yellow, CustomColor.Black);
+                case ColorKind.Custom: return string.Format(CultureInfo.InvariantCulture, "{0:F},{1:F},{2:F},{3:F}", CustomColor.Cyan, CustomColor.Magenta, CustomColor.Yellow, CustomColor.Black) + (Overprint ? " overprint" : "");
                 default: return base.ToString();
             }
         }
@@ -1620,6 +1624,9 @@ namespace PurplePen
                 return SpecialColor.LowerPurple;
             else {
                 float c, m, y, k;
+                bool overprint = s.EndsWith(" overprint");
+                if (overprint)
+                    s = s.Substring(0, s.Length - 10);
                 string[] colors = s.Split(',');
                 if (colors.Length != 4)
                     throw new FormatException();
@@ -1627,7 +1634,7 @@ namespace PurplePen
                 m = float.Parse(colors[1], CultureInfo.InvariantCulture);
                 y = float.Parse(colors[2], CultureInfo.InvariantCulture);
                 k = float.Parse(colors[3], CultureInfo.InvariantCulture);
-                return new SpecialColor(c, m, y, k);
+                return new SpecialColor(c, m, y, k, overprint);
             }
         }
 
@@ -1640,7 +1647,7 @@ namespace PurplePen
             if (Kind != ColorKind.Custom)
                 return Kind == other.Kind;
             else
-                return (Kind == other.Kind && CustomColor.Equals(other.CustomColor));
+                return (Kind == other.Kind && CustomColor.Equals(other.CustomColor) && Overprint == other.Overprint);
         }
 
         public override int GetHashCode()

--- a/src/PurplePen/EventDB.cs
+++ b/src/PurplePen/EventDB.cs
@@ -1578,25 +1578,25 @@ namespace PurplePen
         public readonly CmykColor CustomColor;
         public readonly bool Overprint;
 
-        public readonly static SpecialColor Black = new SpecialColor(ColorKind.Black, false);
-        public readonly static SpecialColor UpperPurple = new SpecialColor(ColorKind.UpperPurple, false);
-        public readonly static SpecialColor LowerPurple = new SpecialColor(ColorKind.LowerPurple, false);
+        public readonly static SpecialColor Black = new SpecialColor(ColorKind.Black);
+        public readonly static SpecialColor UpperPurple = new SpecialColor(ColorKind.UpperPurple);
+        public readonly static SpecialColor LowerPurple = new SpecialColor(ColorKind.LowerPurple);
 
-        public SpecialColor(ColorKind colorKind, bool overprint)
+        public SpecialColor(ColorKind colorKind, bool overprint = false)
         {
             Debug.Assert(colorKind != ColorKind.Custom);
             this.Kind = colorKind;
             this.Overprint = overprint;
         }
 
-        public SpecialColor(float cyan, float magenta, float yellow, float black, bool overprint)
+        public SpecialColor(float cyan, float magenta, float yellow, float black, bool overprint = false)
         {
             this.Kind = ColorKind.Custom;
             this.CustomColor = CmykColor.FromCmyk(cyan, magenta, yellow, black);
             this.Overprint = overprint;
         }
 
-        public SpecialColor(CmykColor color, bool overprint)
+        public SpecialColor(CmykColor color, bool overprint = false)
         {
             this.Kind = ColorKind.Custom;
             this.CustomColor = color;

--- a/src/PurplePen/EventDB.cs
+++ b/src/PurplePen/EventDB.cs
@@ -1609,12 +1609,12 @@ namespace PurplePen
                 case ColorKind.Black: return "black";
                 case ColorKind.UpperPurple: return "purple";
                 case ColorKind.LowerPurple: return "lower-purple";
-                case ColorKind.Custom: return string.Format(CultureInfo.InvariantCulture, "{0:F},{1:F},{2:F},{3:F}", CustomColor.Cyan, CustomColor.Magenta, CustomColor.Yellow, CustomColor.Black) + (Overprint ? " overprint" : "");
+                case ColorKind.Custom: return string.Format(CultureInfo.InvariantCulture, "{0:F},{1:F},{2:F},{3:F}", CustomColor.Cyan, CustomColor.Magenta, CustomColor.Yellow, CustomColor.Black);
                 default: return base.ToString();
             }
         }
 
-        public static SpecialColor Parse(string s)
+        public static SpecialColor Parse(string s, bool overprint)
         {
             if (s == "black")
                 return SpecialColor.Black;
@@ -1624,9 +1624,6 @@ namespace PurplePen
                 return SpecialColor.LowerPurple;
             else {
                 float c, m, y, k;
-                bool overprint = s.EndsWith(" overprint");
-                if (overprint)
-                    s = s.Substring(0, s.Length - 10);
                 string[] colors = s.Split(',');
                 if (colors.Length != 4)
                     throw new FormatException();
@@ -1948,7 +1945,8 @@ namespace PurplePen
                     numColumns = xmlinput.GetAttributeInt("columns", 1);
 
                     if (kind == SpecialKind.Text || kind == SpecialKind.Line || kind == SpecialKind.Rectangle || kind == SpecialKind.Ellipse) {
-                        color = xmlinput.GetAttributeColor("color", SpecialColor.UpperPurple);
+                        bool overprint = xmlinput.GetAttributeBool("overprint", false);
+                        color = xmlinput.GetAttributeColor("color", SpecialColor.UpperPurple, overprint);
                     }
 
                     string lineKindValue = xmlinput.GetAttributeString("line-kind", "");
@@ -2084,6 +2082,7 @@ namespace PurplePen
                     case LineKind.Dashed: xmloutput.WriteAttributeString("line-kind", "dashed"); break;
                 }
                 xmloutput.WriteAttributeString("color", color.ToString());
+                xmloutput.WriteAttributeString("overprint", color.Overprint.ToString().ToLower());
                 xmloutput.WriteAttributeString("line-width", XmlConvert.ToString(lineWidth));
                 if (lineKind == LineKind.Double || lineKind == LineKind.Dashed)
                     xmloutput.WriteAttributeString("gap-size", XmlConvert.ToString(gapSize));

--- a/src/PurplePen/LinePropertiesDialog.cs
+++ b/src/PurplePen/LinePropertiesDialog.cs
@@ -170,6 +170,8 @@ namespace PurplePen
 
         private void pictureBoxPreview_Paint(object sender, PaintEventArgs e)
         {
+            Console.WriteLine("pictureBoxPreview_Paint", this.Color.ToString());
+
             // Get the graphics, size to 10 mm high.
             float scale = 10.0F / pictureBoxPreview.ClientSize.Height;
             Graphics g = e.Graphics;

--- a/src/PurplePen/XmlInput.cs
+++ b/src/PurplePen/XmlInput.cs
@@ -249,14 +249,14 @@ namespace PurplePen
             return XmlConvert.ToBoolean(value);
         }
 
-        public SpecialColor GetAttributeColor(string name, SpecialColor defValue)
+        public SpecialColor GetAttributeColor(string name, SpecialColor defValue, bool overprint)
         {
             string value = Reader.GetAttribute(name);
             if (value == null || value == string.Empty)
                 return defValue;
             else {
                 try {
-                    return SpecialColor.Parse(value);
+                    return SpecialColor.Parse(value, overprint);
                 }
                 catch (FormatException) {
                     BadXml("Bad format for color attribute '{0}'", name);


### PR DESCRIPTION
This PR enables flagging custom colors to be overprinted. The feature solves a major issue with children's string courses by enabling the blending of the guiding line with the background.