### PR TITLE
Fix NullReferenceException in SkiaFontManager when few fonts are installed

### DIFF
--- a/src/MapModel/Map_SkiaStd/EnhancedTypeface.cs
+++ b/src/MapModel/Map_SkiaStd/EnhancedTypeface.cs
@@ -1079,6 +1079,13 @@ namespace Map_SkiaStd
                 // so we have to apply some heuristics (encapsulated in IsGoodFamilyNameMatch) to the result to determine
                 // if it's a good match or just a fallback.
                 SKTypeface typeface = SKTypeface.FromFamilyName(familyName, weight, width, slant);
+                if (typeface == null) {
+                    // On Linux, Skia's fontconfig backend does return null here when the
+                    // requested family is unavailable and the installed font set is small.
+                    // Returning null is what this method documents for "no match", and the
+                    // callers already handle it by falling back to the default font family.
+                    return null;
+                }
                 if (!IsGoodFamilyNameMatch(familyName, typeface)) {
                     typeface.Dispose();
                     return null;
@@ -1106,7 +1113,8 @@ namespace Map_SkiaStd
 
             // If its the default fallback family, it's not a good match.
             // This is a heuristic to detect when Skia fails to find any reasonable match and just returns the default font.
-            return (result.FamilyName != skiaDefaultFont.FamilyName);
+            // skiaDefaultFont can itself be null when few fonts are installed.
+            return (skiaDefaultFont == null || result.FamilyName != skiaDefaultFont.FamilyName);
         }
 
 

--- a/src/MapModel/Map_SkiaStd/EnhancedTypeface.cs
+++ b/src/MapModel/Map_SkiaStd/EnhancedTypeface.cs
@@ -1075,17 +1075,15 @@ namespace Map_SkiaStd
                     }
                 }
 
-                // SKTypeface.FromFamilyName always returns something. We want to return null if it can't find a reasonable match,
-                // so we have to apply some heuristics (encapsulated in IsGoodFamilyNameMatch) to the result to determine
-                // if it's a good match or just a fallback.
+                // On Linux, SKTypeface.FromFamilyName might return null if the requested family is unavailable and
+                // the installed font set is small.
                 SKTypeface typeface = SKTypeface.FromFamilyName(familyName, weight, width, slant);
                 if (typeface == null) {
-                    // On Linux, Skia's fontconfig backend does return null here when the
-                    // requested family is unavailable and the installed font set is small.
-                    // Returning null is what this method documents for "no match", and the
-                    // callers already handle it by falling back to the default font family.
                     return null;
                 }
+                // We want to return null if it can't find a reasonable match,
+                // so we have to apply some heuristics (encapsulated in IsGoodFamilyNameMatch) to the result to determine
+                // if it's a good match or just a fallback.
                 if (!IsGoodFamilyNameMatch(familyName, typeface)) {
                     typeface.Dispose();
                     return null;


### PR DESCRIPTION
While working on an OCAD renderer for https://omaps.me I (or better: Claude) found a bug in PurplePen when only few fonts are installed on the machine. 

> **AI Notice**
>  The code change was written with the help of Claude Code.
> It was reviewed and tested by myself. We ran only a manual test with marymoor.ocd und Lake Sammamish.ocd and not the  whole PurplePen test suite as the code changes are quite small and we do not run it on a windows machine.

### Context

We use `MapModel` server-side to render OCAD maps into map tiles. The container
that runs it is deliberately minimal, which is how we ran into this — a desktop
install has enough fonts that `FromFamilyName` always finds a fallback.

### Bug description

On Linux, reading any OCAD map that contains text crashes with a
`NullReferenceException` when only a small set of fonts is installed:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Map_SkiaStd.SkiaFontManager.IsGoodFamilyNameMatch(String requestedFamily, SKTypeface result) in EnhancedTypeface.cs:line 1098
   at Map_SkiaStd.SkiaFontManager.CreateTypefaceFromSystemOrPrivate(String familyName, ...) in EnhancedTypeface.cs:line 1082
   at Map_SkiaStd.SkiaFontManager.TryGetTypefaceFromNameAndStyle(String familyName, ...)
   at PurplePen.MapModel.SkiaFont..ctor(String familyName, Single emHeight, TextEffects effects)
   at PurplePen.MapModel.Skia_TextMetrics.GetTextFaceMetrics(String familyName, Single emHeight, TextEffects effects)
   at PurplePen.MapModel.TextSymDef.CreateFontMetrics()
   at PurplePen.MapModel.TextSymDef.get_FontAscent()
   at PurplePen.MapModel.OcadImport.CreateTextSymbol(OcadObject obj, TextSymDef symdef, Boolean formatted)
   at PurplePen.MapModel.OcadImport.ReadOcadFile(Byte[] bytes, String filename)
```

### Cause

`CreateTypefaceFromSystemOrPrivate` assumes that `SKTypeface.FromFamilyName`
never returns `null` — the comment right above the call says so:

```csharp
// SKTypeface.FromFamilyName always returns something. We want to return null if it can't find a reasonable match,
```

With Skia's fontconfig backend on Linux that does not hold. When the requested
family is not installed and the available font set is small, it returns `null`,
and `IsGoodFamilyNameMatch` dereferences it on its first line.

### Reproduction

Debian trixie container, .NET 10, SkiaSharp 3.119.4, reading
`src/TestFiles/marymoor.ocd` (which asks for `Arial` and `Arial New Roman`):

| installed fonts | families visible to fontconfig | result |
| --- | ---: | --- |
| `fontconfig` + `fonts-liberation` | 3 | **crash** |
| the above + `fonts-freefont-ttf` | 6 | **crash** |
| all of `/usr/share/fonts/truetype` (incl. DejaVu, Noto) | 18 | works |

The same happens on a normal desktop by pointing `FONTCONFIG_FILE` at a config
that exposes only the Liberation directory. Including `/etc/fonts/conf.d`, so
that the metric aliases (`Arial` → `Liberation Sans`) are active, makes no
difference.

### Fix

Return `null` when `FromFamilyName` returns `null`. That is what the method
already documents:

> Returns null (not a default typeface) if no matching typeface in the system or
> private registry.

and the callers already handle it: `TryGetTypefaceFromNameAndStyle` passes the
`null` on, and `CreateTypeface` falls back to `defaultFontFamilyName` and, as a
last resort, to `SKTypeface.FromFamilyName(defaultFontFamilyName, …)`. So the
fallback chain was complete — only this one link was missing.

The patch also guards `skiaDefaultFont` (line 784,
`SKTypeface.FromFamilyName(null)`), which can be `null` for the same reason and
is dereferenced at the end of `IsGoodFamilyNameMatch`.

### Verification

With the patch applied, on the three-family container, `inspect` and a full
render of `marymoor.ocd` (2554 objects) and `Lake Sammamish.ocd` (OCAD 6) both
succeed, and text renders through the metric-alias substitution.